### PR TITLE
Fix account modal hooks

### DIFF
--- a/libs/base/src/lib/hooks/useAccountModal.tsx
+++ b/libs/base/src/lib/hooks/useAccountModal.tsx
@@ -5,7 +5,7 @@ import { useModal } from 'react-modal-hook'
 import { ViewportWidth } from '@apps/base/theme'
 import { Modal, Address, Button } from '@apps/components/core'
 
-import { useConnected, useReset, useWallet, useWalletAddress } from '../context/AccountProvider'
+import { useConnected, useReset, useWallet, useWalletAddress } from '@apps/base/context/account'
 import { Balances } from '../components/wallet/Balances'
 import { useExploreAssetModal } from './useExploreAssetModal'
 


### PR DESCRIPTION
- Ensure that the account modal calls its hooks within the modal component function, rather than outside the scope, where they may not be defined