### PR TITLE
Add temporary feeders subgraph URL

### DIFF
--- a/libs/base/src/lib/context/NetworkProvider.tsx
+++ b/libs/base/src/lib/context/NetworkProvider.tsx
@@ -234,7 +234,11 @@ const ETH_MAINNET: EthereumMainnet = {
     staking: [graphHostedEndpoint('mstable', 'mstable-staking')],
     questbook: ['https://europe-west1-mstable-questbook.cloudfunctions.net/questbook'],
     snapshot: ['https://hub.snapshot.org/graphql'],
-    feeders: [graphMainnetEndpoint('0x021c1a1ce318e7b4545f6280b248062592b71706', 0, process.env.NX_FEEDERS_SUBGRAPH_API_KEY as string)],
+    feeders: [
+      // Temporary preview URL because indexers haven't picked up the new version...
+      'https://api.studio.thegraph.com/query/948/mstable-feeder-pools-and-vaults/v0.0.9',
+      graphMainnetEndpoint('0x021c1a1ce318e7b4545f6280b248062592b71706', 0, process.env.NX_FEEDERS_SUBGRAPH_API_KEY as string),
+    ],
     blocks: [graphHostedEndpoint('blocklytics', 'ethereum-blocks')],
   },
   addresses: {


### PR DESCRIPTION
Temporary preview URL because indexers haven't picked up the new version.
