### PR TITLE
fix: remove reset when account undefined

### DIFF
--- a/libs/base/src/lib/updaters/tokenSubscriptionsUpdater.ts
+++ b/libs/base/src/lib/updaters/tokenSubscriptionsUpdater.ts
@@ -83,7 +83,7 @@ export const TokenSubscriptionsUpdater = (): null => {
 
   // Clear all contracts and tokens if the account/chain changes.
   useEffect(() => {
-    if (prevAccount !== account || !account || chainId !== prevChainId) {
+    if (prevAccount !== account || chainId !== prevChainId) {
       reset()
     }
   }, [account, chainId, prevAccount, prevChainId, reset])


### PR DESCRIPTION
Since `StakeBalances` runs before `TokenSubscriptionsUpdater` and by the time `TokenSubscriptionsUpdater` first run the account is `undefined` it resets the subscription state.
