### PR TITLE
Prioritise published feeders subgraph

### DIFF
--- a/libs/base/src/lib/components/core/NotificationItem.tsx
+++ b/libs/base/src/lib/components/core/NotificationItem.tsx
@@ -25,6 +25,10 @@ const Link = styled.a<{ nType: NotificationType }>`
   }
 `
 
+const Body = styled.div`
+  font-size: 0.75rem !important;
+`
+
 const Container = styled.div<Pick<Notification, 'type'> & { className?: string }>`
   background: ${({ theme, type }) =>
     type === NotificationType.Success ? theme.color.green : type === NotificationType.Info ? theme.color.primary : theme.color.red};
@@ -38,7 +42,7 @@ const Container = styled.div<Pick<Notification, 'type'> & { className?: string }
   > * {
     font-size: 0.85rem;
     &:not(:last-child) {
-      margin-bottom: 0.25rem;
+      margin-bottom: 0.2rem;
     }
   }
 
@@ -60,7 +64,7 @@ export const NotificationItem: FC<{
   return (
     <Container type={type} onClick={handleClick} className={className}>
       <Title>{title}</Title>
-      {body && <div>{body}</div>}
+      {body && <Body>{body}</Body>}
       {link && (
         <Link nType={type} href={link.href} target="_blank" rel="noopener noreferrer">
           {link.title}

--- a/libs/base/src/lib/context/NetworkProvider.tsx
+++ b/libs/base/src/lib/context/NetworkProvider.tsx
@@ -238,9 +238,9 @@ const ETH_MAINNET: EthereumMainnet = {
     merkleDrop: [graphHostedEndpoint('mstable', 'mstable-merkle-drop')],
     snapshot: ['https://hub.snapshot.org/graphql'],
     feeders: [
+      graphMainnetEndpoint('0x021c1a1ce318e7b4545f6280b248062592b71706', 0, process.env.NX_FEEDERS_SUBGRAPH_API_KEY as string),
       // Temporary preview URL because indexers haven't picked up the new version...
       'https://api.studio.thegraph.com/query/948/mstable-feeder-pools-and-vaults/v0.0.9',
-      graphMainnetEndpoint('0x021c1a1ce318e7b4545f6280b248062592b71706', 0, process.env.NX_FEEDERS_SUBGRAPH_API_KEY as string),
     ],
     blocks: [graphHostedEndpoint('blocklytics', 'ethereum-blocks')],
   },


### PR DESCRIPTION
- Prioritise the published feeder pools subgraph over the temporary URL, because indexers are now available
- Add context to Apollo timeout errors by adding the operation name (e.g. "Subgraph: Massets" for the massets query) as the notification body


| Timeout errors |
|--------------|
|<img src="https://user-images.githubusercontent.com/5450382/143461973-00402cfc-5d49-4f2b-8cf3-b44f408dc5c7.png" width="320" />|
