### PR TITLE
Fix: claiming for dual vaults

### DIFF
--- a/libs/base/src/lib/context/NetworkProvider.tsx
+++ b/libs/base/src/lib/context/NetworkProvider.tsx
@@ -239,7 +239,7 @@ const ETH_MAINNET: EthereumMainnet = {
     snapshot: ['https://hub.snapshot.org/graphql'],
     feeders: [
       // Temporary preview URL because indexers haven't picked up the new version...
-      'https://api.studio.thegraph.com/query/948/mstable-feeder-pools-and-vaults/v0.0.11',
+      'https://api.studio.thegraph.com/query/948/mstable-feeder-pools-and-vaults/v0.0.13',
       graphMainnetEndpoint('0x021c1a1ce318e7b4545f6280b248062592b71706', 0, process.env.NX_FEEDERS_SUBGRAPH_API_KEY as string),
     ],
     blocks: [graphHostedEndpoint('blocklytics', 'ethereum-blocks')],


### PR DESCRIPTION
**Update subgraph**

- Update the subgraph to properly handle dual vaults that don't have platform tokens

**Fix claiming earlier ranges**

- Get the unclaimed rewards from the vault contract to use as the claim range
