### PR TITLE
fix: Boost director

### DIFF
--- a/apps/protocol/src/app/components/PokeBoost.tsx
+++ b/apps/protocol/src/app/components/PokeBoost.tsx
@@ -110,7 +110,9 @@ export const PokeBoost: FC<Props> = ({ apy, vault }) => {
   const rewardStreams = useRewardStreams()
 
   const boostNeedsPoke = !!account?.boostMultiplier && (account.boostMultiplier ?? 0) < (userBoost ?? 0)
-  const boostNeedsDirector = boostNeedsPoke && account?.boostMultiplier === 1
+  // FIXME: - Subgraph needs updating
+  const boostNeedsDirector = false
+  // const boostNeedsDirector = boostNeedsPoke && account?.boostMultiplier === 1
   const message = isImusd ? 'Claim rewards to update your reward rate.' : 'Poke the contract or claim rewards to update your reward rate.'
 
   if (boostNeedsDirector) return <SelectBoost vault={vault} />

--- a/apps/protocol/src/app/components/PokeBoost.tsx
+++ b/apps/protocol/src/app/components/PokeBoost.tsx
@@ -109,14 +109,19 @@ export const PokeBoost: FC<Props> = ({ apy, vault }) => {
   const userBoost = useCalculateUserBoost(vault)
   const rewardStreams = useRewardStreams()
 
-  const boostNeedsPoke = !!account?.boostMultiplier && (account.boostMultiplier ?? 0) < (userBoost ?? 0)
-  // FIXME: - Subgraph needs updating
-  const boostNeedsDirector = false
-  // const boostNeedsDirector = boostNeedsPoke && account?.boostMultiplier === 1
+  const isUserBoostActive = !!account?.boostMultiplier
+  const isUserBalanceNonZero = !!account?.rawBalance?.simple
+  const isUserBoostLessThanCalc = (account?.boostMultiplier ?? 0) < (userBoost ?? 0)
+  const showBoostPoke = isUserBoostActive && isUserBalanceNonZero && isUserBoostLessThanCalc
+  const showBoostDirector = false
+
+  // FIXME: - Subgraph needs updating; restore after.
+  // const showBoostDirector = boostNeedsPoke && account?.boostMultiplier === 1
+
   const message = isImusd ? 'Claim rewards to update your reward rate.' : 'Poke the contract or claim rewards to update your reward rate.'
 
-  if (boostNeedsDirector) return <SelectBoost vault={vault} />
-  if (!boostNeedsPoke) return null
+  if (showBoostDirector) return <SelectBoost vault={vault} />
+  if (!showBoostPoke) return null
 
   return (
     <Container>


### PR DESCRIPTION
## Changelog:
- Subgraph is not picking up correct data & so it will show boost director message on newer pools. This temp hides until data is resolved. As the boosted pools limit is now 6, it's unlikely that a user will have hit that limit