### PR TITLE
Handle lack of simple message signing for e.g. Gnosis Safe + WalletConnect

### DIFF
--- a/apps/governance/src/app/pages/Stake/StakeForm.tsx
+++ b/apps/governance/src/app/pages/Stake/StakeForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react'
+import React, { FC } from 'react'
 import { useToggle } from 'react-use'
 import styled from 'styled-components'
 import { constants } from 'ethers'

--- a/apps/governance/src/app/pages/Stake/StakeForm.tsx
+++ b/apps/governance/src/app/pages/Stake/StakeForm.tsx
@@ -182,7 +182,7 @@ export const StakeForm: FC<Props> = ({ className, isMigrating = false }) => {
           <SendButton valid={canUserStake} title="Stake in V2" handleSend={handleDeposit} />
         </div>
       ) : (
-        <SendButton valid={canUserStake} title="Stake" handleSend={handleDeposit} />
+        <SendButton valid title="Stake" handleSend={handleDeposit} />
       )}
     </Container>
   )

--- a/libs/base/src/lib/hooks/useStakeSignatures.tsx
+++ b/libs/base/src/lib/hooks/useStakeSignatures.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from 'react'
 import { useLocalStorage } from 'react-use'
 
 export interface StakeSignatures {
@@ -6,7 +7,4 @@ export interface StakeSignatures {
 
 // small hack because the returned types are wrong: https://github.com/streamich/react-use/pull/1438
 export const useStakeSignatures = () =>
-  useLocalStorage<StakeSignatures>('stakeSignatures', {}) as unknown as [
-    StakeSignatures,
-    React.Dispatch<React.SetStateAction<StakeSignatures>>,
-  ]
+  useLocalStorage<StakeSignatures>('stakeSignatures', {}) as unknown as [StakeSignatures, Dispatch<SetStateAction<StakeSignatures>>]


### PR DESCRIPTION
- When signing stake signatures, detect Gnosis Safe/WalletConect and use skip the signing process entirely