### PR TITLE
Remove insufficient balance check

### DIFF
--- a/libs/base/src/lib/components/wallet/PendingTransactions.tsx
+++ b/libs/base/src/lib/components/wallet/PendingTransactions.tsx
@@ -156,7 +156,7 @@ export const PendingTransaction: FC<{
   const signer = useSigner()
   const wallet = useWallet()
   const { cancel, send } = useTransactionsDispatch()
-  const { estimationError, gasLimit, gasPrice, insufficientBalance } = useGas()
+  const { estimationError, gasLimit, gasPrice } = useGas()
   const [{ appName }] = useBaseCtx()
 
   const [stakeSignatures, setStakeSignatures] = useStakeSignatures()
@@ -189,7 +189,6 @@ export const PendingTransaction: FC<{
     estimationError ||
     !gasLimit ||
     !gasPrice ||
-    insufficientBalance ||
     transaction.status !== TransactionStatus.Pending ||
     (checkTransactionSignature && !isStakeSigned && !isStakeSignedForm)
   )


### PR DESCRIPTION
- Remove the `insufficientBalance` check for pending transactions; the wallet should be responsible, and it breaks some WalletConnect apps (e.g. Safes don't need ETH, only Safe owners do)