### PR TITLE
feat: Add platform reward amount

### DIFF
--- a/apps/protocol/src/app/context/RewardStreamsProvider.tsx
+++ b/apps/protocol/src/app/context/RewardStreamsProvider.tsx
@@ -7,6 +7,7 @@ import { BoostedSavingsVault, BoostedSavingsVault__factory } from '@apps/artifac
 import { useAccount, useSigner } from '@apps/base/context/account'
 import { BoostedSavingsVaultAccountState, BoostedSavingsVaultState } from '@apps/data-provider'
 import { SCALE } from '@apps/types'
+import { BigDecimal } from '@apps/bigdecimal'
 
 type RewardEntry = BoostedSavingsVaultAccountState['rewardEntries'][number]
 
@@ -39,6 +40,7 @@ export interface RewardStreams {
     locked: number
     unlocked: number
     previewLocked: number
+    platform: number
   }
   nextUnlock?: number
   chartData: ChartData
@@ -129,9 +131,7 @@ export const RewardStreamsProvider: FC<{
   const vaultContract = useRef<BoostedSavingsVault>()
 
   useEffect(() => {
-    if (!signer || !account || !vault) {
-        return
-    }
+    if (!signer || !account || !vault) return
 
     if (!vaultContract.current) {
       vaultContract.current = BoostedSavingsVault__factory.connect(vault.address, signer)
@@ -161,6 +161,7 @@ export const RewardStreamsProvider: FC<{
       const {
         lockupDuration,
         account: { rewardEntries, lastClaim, lastAction },
+        account,
       } = vault
 
       const [unlockedStreams, lockedStreams] = rewardEntries
@@ -277,12 +278,15 @@ export const RewardStreamsProvider: FC<{
         return
       }
 
+      const platform = parseInt((account?.platformRewards ?? 0).toString()) / 1e18
+
       const amounts = {
         earned,
         locked,
         previewLocked,
         unlocked,
         total,
+        platform,
       }
 
       return {

--- a/apps/protocol/src/app/context/RewardStreamsProvider.tsx
+++ b/apps/protocol/src/app/context/RewardStreamsProvider.tsx
@@ -7,7 +7,6 @@ import { BoostedSavingsVault, BoostedSavingsVault__factory } from '@apps/artifac
 import { useAccount, useSigner } from '@apps/base/context/account'
 import { BoostedSavingsVaultAccountState, BoostedSavingsVaultState } from '@apps/data-provider'
 import { SCALE } from '@apps/types'
-import { BigDecimal } from '@apps/bigdecimal'
 
 type RewardEntry = BoostedSavingsVaultAccountState['rewardEntries'][number]
 

--- a/apps/protocol/src/app/pages/Pools/Detail/PoolOverview.tsx
+++ b/apps/protocol/src/app/pages/Pools/Detail/PoolOverview.tsx
@@ -88,18 +88,18 @@ export const PoolOverview: FC = () => {
             )}
           </Button>
           <Button active={selection === Rewards} onClick={() => handleSelection(Rewards)}>
-            <h3>Rewards</h3>
+            <h3>{vault?.rewardsToken.symbol} Rewards</h3>
             <div>
               <CountUp end={totalEarned} suffix={` ${vault?.rewardsToken.symbol}`} />
               <Tooltip tip={`${vault?.rewardsToken.symbol} rewards unlock over time`} />
             </div>
           </Button>
-          {!!apy.value?.platformRewards && (
+          {!!rewardStreams.amounts.platform && (
             <Button active={false} disabled>
-              <h3>Platform APY</h3>
+              <h3>{vault?.platformRewardsToken?.symbol} Rewards</h3>
               <div>
-                <CountUp end={apy.value.platformRewards} suffix="%" />
-                <Tooltip tip={`${vault?.platformRewardsToken?.symbol} rewards are claimed immediately`} />
+                <CountUp end={rewardStreams.amounts.platform} suffix={` ${vault?.platformRewardsToken?.symbol}`} />
+                <Tooltip tip={`${vault?.platformRewardsToken?.symbol} rewards can be claimed immediately`} />
               </div>
             </Button>
           )}

--- a/libs/data-provider/src/lib/types.ts
+++ b/libs/data-provider/src/lib/types.ts
@@ -106,6 +106,7 @@ export interface BoostedSavingsVaultAccountState {
   rawBalance: BigDecimal
   lastAction: number
   lastClaim: number
+  platformRewards?: BigNumber
   rewardCount: number
   rewardPerTokenPaid: BigNumber
   rewards: BigNumber


### PR DESCRIPTION
## Changelog:
- Show platform rewards earned rather than % APY in PoolOverview section (platform apy already shown in Card view above)