### PR TITLE
chore: Remove olympus message

### DIFF
--- a/apps/protocol/src/app/index.tsx
+++ b/apps/protocol/src/app/index.tsx
@@ -99,11 +99,6 @@ export const ProtocolApp: FC = () => {
       message = MessageHandler.graph
     }
 
-    // Temporary, revert after some time.
-    if (isEthMainnet) {
-      message = MessageHandler.olympus
-    }
-
     if (undergoingRecol) {
       message = (undergoingRecol && MessageHandler.recollat(massetConfig)) || undefined
     }

--- a/libs/base/src/lib/components/forms/TransactionInfo.tsx
+++ b/libs/base/src/lib/components/forms/TransactionInfo.tsx
@@ -41,9 +41,19 @@ const Info = styled.div`
   padding: 0.375rem 0;
   font-size: 0.875rem;
 
+  > :last-child {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
   > span:last-child {
     font-size: 1rem;
     ${({ theme }) => theme.mixins.numeric}
+
+    > :last-child {
+      font-size: 0.875rem;
+    }
   }
 `
 
@@ -151,12 +161,12 @@ export const TransactionInfo: FC<Props> = ({
               </span>
             </Info>
           )}
-          {!!impactPercentage && (
+          {impactPercentage && impactPercentage >= 0.01 && (
             <Info>
               <p>
                 <Tooltip tip="The difference between the current rate and estimated rate due to trade size">Price impact</Tooltip>
               </p>
-              <Impact warning={showImpactWarning}>{impactPercentage < 0.01 ? `<0.01%` : `${impactPercentage?.toFixed(2)}%`}</Impact>
+              <Impact warning={showImpactWarning}>{`${impactPercentage?.toFixed(4)}%`}</Impact>
             </Info>
           )}
           {formattedDistancePercentage && (


### PR DESCRIPTION
## Changelog
- Removes olympus message (bonding period is now over)
- Tidies layout on Swap for larger numbers
- Hides price impact message if < 0.01%