### PR TITLE
fix: replace IPFS gateway

### DIFF
--- a/libs/merkle-claim/src/lib/utils.ts
+++ b/libs/merkle-claim/src/lib/utils.ts
@@ -42,7 +42,8 @@ export const createMerkleClaimProofs = async (claimant: string, { tranches }: Me
 
   return Promise.all(
     tranches.map(async ({ uri, trancheId }) => {
-      const url = `https://cloudflare-ipfs.com/ipfs/${(uri as string).split('ipfs://')[1]}`
+      // const url = `https://cloudflare-ipfs.com/ipfs/${(uri as string).split('ipfs://')[1]}`
+      const url = `https://gateway.pinata.cloud/ipfs/${(uri as string).split('ipfs://')[1]}`
       const response = await fetch(url)
       const balances = (await response.json()) as Record<string, string>
       return { ...getProof(balances, claimant), trancheId }


### PR DESCRIPTION
Cloudflare IPFS gateway often returns 524 Error, the file might be garbage collected from their gateway. I was using Pinata to pin the file remotely and the pinata gateway seems to be therefore more reliable. 