### PR TITLE
fix: hide baseApy when lower than 0.05

### DIFF
--- a/apps/protocol/src/app/pages/Pools/cards/PoolDetailCard.tsx
+++ b/apps/protocol/src/app/pages/Pools/cards/PoolDetailCard.tsx
@@ -180,7 +180,7 @@ export const PoolDetailCard: FC<Props> = ({ poolAddress, className }) => {
           </RewardsAPY>
         )}
         <div />
-        {!!baseApy && (
+        {baseApy > 0.05 && (
           <RewardsAPY>
             <p>
               <Tooltip tip="Base APY represents the increase in the value of the pool token over time.">Base APY</Tooltip>


### PR DESCRIPTION
I replicated logic found on the [cards](https://github.com/mstable/mStable-apps/blob/af71e6e2efd6b21a062fb8c7b04b15994b0d16ea/apps/protocol/src/app/pages/Pools/cards/PoolCard.tsx#L164)